### PR TITLE
Fix BooleanDateTime for nullable fields

### DIFF
--- a/src/BooleanDatetime.php
+++ b/src/BooleanDatetime.php
@@ -75,6 +75,10 @@ class BooleanDatetime extends Field
             $attribute,
             $resolveCallback ??
                 function ($value) {
+                    if (empty($value)) {
+                        return null;   
+                    }
+                    
                     if (!$value instanceof DateTimeInterface) {
                         throw new Exception(
                             "DateTime field must cast to 'datetime' in Eloquent model."


### PR DESCRIPTION
When the value is `null` in the database, the resolveCallback is still called. This ensures we just return a null value when the value is empty.

Fixes #5 